### PR TITLE
Upgrade to Userscripter 3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "ts-type-guards": "^0.6.1",
         "typescript": "^3.7.4",
         "userscript-metadata": "^1.0.0",
-        "userscripter": "3.0.0",
+        "userscripter": "3.0.5",
         "webpack": "^4.41.5",
         "webpack-cli": "^3.3.10"
       }
@@ -45,15 +45,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
-    },
-    "node_modules/@types/loader-utils": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.9.tgz",
-      "integrity": "sha512-2NrfPIjGI8ZuEBtMQHQ71Rf+dyZayiuf4EyJYBTvh5fbNLAmQ7AIpjbPRJ5CXEBJVfSgtoi02pI/yNaVAgxMYg==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webpack": "^4"
-      }
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
@@ -4725,13 +4716,11 @@
       }
     },
     "node_modules/userscripter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.0.tgz",
-      "integrity": "sha512-aa4KvpKilmQJMC3/x9kpPDNNgjMKTuUof+PdsVFs3HO6yKZp7MhXFmdSAjzzSy3UvRrnjmiD4LCFnlHJTsqxYg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.5.tgz",
+      "integrity": "sha512-yFCQSEWp+J25B+5/7dEF6txewMc7OYCvyeOt9cikwGqigA/PLhRF70RjnKq6MI5hJO/HgYVgVmXk5rgR+mHx+g==",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",
-        "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
         "@types/node": "^12.12.8",
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
@@ -4740,12 +4729,10 @@
         "css-loader": "^3.2.0",
         "fs-extra": "^8.1.0",
         "lines-unlines": "^1.0.0",
-        "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
-        "schema-utils": "^2.5.0",
         "terser-webpack-plugin": "^2.3.1",
         "to-string-loader": "^1.1.6",
         "ts-loader": "^8.4.0",
@@ -6173,15 +6160,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
-    },
-    "@types/loader-utils": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.9.tgz",
-      "integrity": "sha512-2NrfPIjGI8ZuEBtMQHQ71Rf+dyZayiuf4EyJYBTvh5fbNLAmQ7AIpjbPRJ5CXEBJVfSgtoi02pI/yNaVAgxMYg==",
-      "requires": {
-        "@types/node": "*",
-        "@types/webpack": "^4"
-      }
     },
     "@types/node": {
       "version": "12.20.55",
@@ -9920,13 +9898,11 @@
       }
     },
     "userscripter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.0.tgz",
-      "integrity": "sha512-aa4KvpKilmQJMC3/x9kpPDNNgjMKTuUof+PdsVFs3HO6yKZp7MhXFmdSAjzzSy3UvRrnjmiD4LCFnlHJTsqxYg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-3.0.5.tgz",
+      "integrity": "sha512-yFCQSEWp+J25B+5/7dEF6txewMc7OYCvyeOt9cikwGqigA/PLhRF70RjnKq6MI5hJO/HgYVgVmXk5rgR+mHx+g==",
       "requires": {
         "@types/fs-extra": "^8.0.1",
-        "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
         "@types/node": "^12.12.8",
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
@@ -9935,12 +9911,10 @@
         "css-loader": "^3.2.0",
         "fs-extra": "^8.1.0",
         "lines-unlines": "^1.0.0",
-        "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
-        "schema-utils": "^2.5.0",
         "terser-webpack-plugin": "^2.3.1",
         "to-string-loader": "^1.1.6",
         "ts-loader": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ts-type-guards": "^0.6.1",
     "typescript": "^3.7.4",
     "userscript-metadata": "^1.0.0",
-    "userscripter": "3.0.0",
+    "userscripter": "3.0.5",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   }


### PR DESCRIPTION
The v3.x releases after v3.0.5 only affect the CLI tool, not the library.

Also, from now on, we won't be hard-wrapping commit messages at 72 characters anymore. I've changed the _Default commit message_ setting for the repository from _Pull request title and description_ to _Pull request title_; the description must be manually copied and pasted when merging because, unlike Azure DevOps, GitHub doesn't support using the description without hard-wrapping it.