### PR TITLE
Upgrade to Userscripter 5.0.0

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -1,7 +1,7 @@
 import {
     BuildConfig,
     distFileName,
-} from "userscripter/build";
+} from "userscripter/build-time";
 import Manifest from "webextension-manifest";
 
 import U from "./src/userscript";

--- a/metadata.ts
+++ b/metadata.ts
@@ -1,7 +1,7 @@
 import {
     BuildConfig,
     metadataUrl,
-} from "userscripter/build";
+} from "userscripter/build-time";
 import { Metadata } from "userscript-metadata";
 
 import U from "./src/userscript";

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "ts-type-guards": "^0.6.1",
         "typescript": "^3.7.4",
         "userscript-metadata": "^1.0.0",
-        "userscripter": "4.0.0",
+        "userscripter": "5.0.0",
         "webpack": "^4.41.5",
         "webpack-cli": "^3.3.10"
       }
@@ -4598,9 +4598,9 @@
       }
     },
     "node_modules/userscripter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-4.0.0.tgz",
-      "integrity": "sha512-KHdpe173p179cAYURkI1G251jxjhF7tTLX74TfRGRKL0MWqR2N+YpMDd5dUxqk2cU6aVv85igswEohPRsgD2cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-5.0.0.tgz",
+      "integrity": "sha512-lIvXdu16SFu3UqhfgincC6FPGsIxx7CW27ZAGkKfneYkqgOswEuJleI6R76d2M+C9vHNL/OibGpJktkuQak0mA==",
       "dependencies": {
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
@@ -9589,9 +9589,9 @@
       }
     },
     "userscripter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-4.0.0.tgz",
-      "integrity": "sha512-KHdpe173p179cAYURkI1G251jxjhF7tTLX74TfRGRKL0MWqR2N+YpMDd5dUxqk2cU6aVv85igswEohPRsgD2cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-5.0.0.tgz",
+      "integrity": "sha512-lIvXdu16SFu3UqhfgincC6FPGsIxx7CW27ZAGkKfneYkqgOswEuJleI6R76d2M+C9vHNL/OibGpJktkuQak0mA==",
       "requires": {
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ts-type-guards": "^0.6.1",
     "typescript": "^3.7.4",
     "userscript-metadata": "^1.0.0",
-    "userscripter": "4.0.0",
+    "userscripter": "5.0.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   }

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,6 +1,6 @@
 import { log } from "userscripter";
-import { ALWAYS, DOMCONTENTLOADED } from "userscripter/lib/environment";
-import { Operation, operation } from "userscripter/lib/operations";
+import { ALWAYS, DOMCONTENTLOADED } from "userscripter/run-time/environment";
+import { Operation, operation } from "userscripter/run-time/operations";
 
 import { P, Preferences } from "~src/preferences";
 import { menuGenerator } from "~src/preferences-menu";

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -4,7 +4,7 @@ import {
     PreferenceManager,
     StringPreference,
 } from "ts-preferences";
-import { loggingResponseHandler } from "userscripter/lib/preferences";
+import { loggingResponseHandler } from "userscripter/run-time/preferences";
 
 import U from "~src/userscript";
 import T from "~src/text";

--- a/src/stylesheets.ts
+++ b/src/stylesheets.ts
@@ -1,5 +1,5 @@
-import { ALWAYS } from "userscripter/lib/environment";
-import { Stylesheets, stylesheet } from "userscripter/lib/stylesheets";
+import { ALWAYS } from "userscripter/run-time/environment";
+import { Stylesheets, stylesheet } from "userscripter/run-time/stylesheets";
 
 import { P, Preferences } from "~src/preferences";
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -3,7 +3,7 @@ import {
     createWebpackConfig,
     DEFAULT_BUILD_CONFIG,
     DEFAULT_METADATA_SCHEMA,
-} from "userscripter/build";
+} from "userscripter/build-time";
 
 import MANIFEST from "./manifest";
 import METADATA from "./metadata";


### PR DESCRIPTION
I used this command to adapt the source code, as suggested in SimonAlling/userscripter#153:

```bash
for f in $(git ls-files "$(git rev-parse --show-toplevel)"); do
  sed -i 's#userscripter/build#userscripter/build-time#g' $f
  sed -i 's#userscripter/lib#userscripter/run-time#g' $f
done
```

💡 `git show --color-words='build-time|(\w|\+|=)+|.'`